### PR TITLE
feat: defining dag for zoo_data

### DIFF
--- a/zoo_etl.py
+++ b/zoo_etl.py
@@ -1,4 +1,26 @@
 import pandas as pd
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from datetime import datetime, timedelta
+
+# Default arguments for the DAG
+default_args = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'start_date': datetime.now(),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 1,
+    'retry_delay': timedelta(minutes=5),
+}
+
+# Define the DAG
+dag = DAG(
+    'zoo_etl_pipeline',
+    default_args=default_args,
+    description='ETL pipeline for zoo animal data',
+    schedule_interval=timedelta(days=1),
+)
 
 def extract_zoo_animals():
     '''


### PR DESCRIPTION
## What?
This PR introduces the default arguments for the Airflow Directed Acyclic Graph (DAG) used in the zoo ETL pipeline. These arguments include the owner, dependency settings, start date, email notifications, retry settings, and retry delay.
## Why?
Ensures consistent behavior and configuration across different DAG runs. Makes easier maintenance and readability of the DAG configuration. Specifies retry policies and failure handling mechanisms, which are crucial for reliable pipeline execution.

